### PR TITLE
Fixed multiple beacons issue

### DIFF
--- a/src/android/com/radiusnetworks/ibeacon/Region.java
+++ b/src/android/com/radiusnetworks/ibeacon/Region.java
@@ -140,13 +140,11 @@ public class Region  {
 
 	@Override
 	public int hashCode() {
-		// return this.uniqueId.hashCode();
         return (this.uniqueId + this.proximityUuid + this.major + this.minor).hashCode();
 	}
 	
 	public boolean equals(Object other) {
 		 if (other instanceof Region) {
-             // return ((Region)other).uniqueId.equals(this.uniqueId);
              Region r = (Region) other;
              return r.uniqueId.equals(this.uniqueId) &&
                  r.proximityUuid.equals(this.proximityUuid) &&


### PR DESCRIPTION
Hi @petermetz 
Currently when ranging multiple beacons, if they have the same UUID, even though with different major / minor value, they will be treat as one beacon. Only one of them is detected. 

I think it's not correct. Especially, we bought the Estimote beacons. By default, all the estimote beacons have the same UUID, but with a different major/minor. 
This issue is also reported in issue list #25 . 

Would you please merge my code? Thanks
