### PR TITLE
Fixing Bug in Delegate.safeTraceLogging

### DIFF
--- a/www/Delegate.js
+++ b/www/Delegate.js
@@ -80,7 +80,7 @@ Delegate.safeTraceLogging = function(message) {
 		return;
 	}
 	try {
-		cordova.plugins.LocationManager.appendToDeviceLog(message);
+		cordova.plugins.locationManager.appendToDeviceLog(message);
 	} catch (e) {
 		console.error('Fail in safeTraceLogging()' + e.message, e);
 	}


### PR DESCRIPTION
When running the latest version the Delegate.safeTraceLogging function was causing an error due to Typo
