### PR TITLE
Fix a forgotten reference change in _mapDelegateCallback

### DIFF
--- a/www/LocationManager.js
+++ b/www/LocationManager.js
@@ -135,8 +135,7 @@ LocationManager.prototype._mapDelegateCallback = function (pluginResult) {
 	
 	this.appendToDeviceLog('_mapDelegateCallback() found eventType ' + eventType);
 
-	if (_.isFunction(Delegate[eventType])) {
-		//Delegate[eventType](pluginResult);
+	if (_.isFunction(this.delegate[eventType])) {
 		this.delegate[eventType](pluginResult);
 	} else {
 		console.error('Delegate unable to handle eventType: ' + eventType);


### PR DESCRIPTION
Fix a forgotten reference change in _mapDelegateCallback, made when changed from Klass syntax to the new one.
