### PR TITLE
Added requestStateForRegion to LocationMananger.js

### DIFF
--- a/src/ios/CDVLocationManager.h
+++ b/src/ios/CDVLocationManager.h
@@ -66,6 +66,7 @@ const int CDV_LOCATION_MANAGER_INPUT_PARSE_ERROR = 100;
 
 - (void)startMonitoringForRegion:(CDVInvokedUrlCommand*)command;
 - (void)stopMonitoringForRegion:(CDVInvokedUrlCommand*)command;
+- (void)requestStateForRegion:(CDVInvokedUrlCommand*)command;
 
 - (void)isRangingAvailable:(CDVInvokedUrlCommand*)command;
 - (void)getAuthorizationStatus:(CDVInvokedUrlCommand*)command;

--- a/src/ios/CDVLocationManager.m
+++ b/src/ios/CDVLocationManager.m
@@ -329,6 +329,28 @@
     } :command];
 }
 
+- (void)requestStateForRegion:(CDVInvokedUrlCommand*)command {
+    [self _handleCallSafely:^CDVPluginResult *(CDVInvokedUrlCommand *command) {
+        
+        NSError* error;
+        CLRegion* region = [self parseRegion:command returningError:&error];
+        if (region == nil) {
+            if (error != nil) {
+                [[self getLogger] debugLog:@"ERROR %@", error];
+                return [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:error.userInfo];
+            } else {
+                return [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Unknown error."];
+            }
+        } else {
+            [_locationManager requestStateForRegion:region];
+            CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+            [result setKeepCallbackAsBool:YES];
+            return result;
+        }
+        
+    } :command];
+}
+
 - (void)startRangingBeaconsInRegion:(CDVInvokedUrlCommand*)command {
     [self _handleCallSafely:^CDVPluginResult *(CDVInvokedUrlCommand *command) {
         

--- a/www/LocationManager.js
+++ b/www/LocationManager.js
@@ -269,6 +269,24 @@ LocationManager.prototype.stopMonitoringForRegion = function(region) {
 };
 
 /**
+ * Request state the for specified region. When result is ready
+ * didDetermineStateForRegion is triggered. This can be any region, 
+ * also those which is not currently monitored. 
+ *
+ * This is done asynchronously and may not be immediately reflected in monitoredRegions.
+ *
+ * @param {Region} region An instance of {Region} which will be monitored
+ * by the operating system.
+ * 
+ * @return {Q.Promise} Returns a promise which is resolved as soon as the
+ * native layer acknowledged the dispatch of the request to stop monitoring.
+ */
+LocationManager.prototype.requestStateForRegion = function(region) {
+	Regions.checkRegionType(region);
+	return this._promisedExec('requestStateForRegion', [region], []);
+};
+
+/**
  * Start ranging the specified beacon region.
  *
  * If a region of the same type with the same identifier is already being


### PR DESCRIPTION
Added requestStateForRegion to LocationMananger.js for requesting the current state of a region at any given point. requestStateForRegion is part of the official API ([CoreLocation API on requestStateForRegion](https://developer.apple.com/library/ios/documentation/CoreLocation/Reference/CLLocationManager_Class/index.html#//apple_ref/occ/instm/CLLocationManager/requestStateForRegion:))

I'm one of those who have problems with didEnterRegion and didExitRegion not being sent on app starting up in background mode. Using this I can get around it, and even make a more idempotent setup, not relying on to many events.
