### PR TITLE
Typo in Readme and check in CDVLocationManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ var minor = 1000;
 var major = 5;
 var beaconRegion = new cordova.plugins.locationManager.BeaconRegion(identifier, uuid, major, minor);
 
-cordova.plugins.locationManager.stopRangingBeaconsInRegion(beaconRegion)
+cordova.plugins.locationManager.stopMonitoringForRegion(beaconRegion)
 	.fail(console.error)
 	.done();
 

--- a/src/ios/CDVLocationManager.m
+++ b/src/ios/CDVLocationManager.m
@@ -775,7 +775,7 @@
         region = [[CLBeaconRegion alloc] initWithProximityUUID:uuid identifier:identifier];
     } else if (major != nil && minor == nil){
         region = [[CLBeaconRegion alloc] initWithProximityUUID:uuid major:[major doubleValue] identifier:identifier];
-    } else if (major != nil && major != nil) {
+    } else if (major != nil && minor != nil) {
         region = [[CLBeaconRegion alloc] initWithProximityUUID:uuid major:[major doubleValue] minor:[minor doubleValue] identifier:identifier];
     } else {
         *error = [self parseErrorWithDescription:@"Unsupported combination of 'major' and 'minor' parameters."];


### PR DESCRIPTION
Fix typo in readme and a double ‘major’ check in CDVLocationManager