### PR TITLE
Delegate method monitoringDidFailForRegionWithError added

### DIFF
--- a/src/ios/CDVLocationManager.m
+++ b/src/ios/CDVLocationManager.m
@@ -181,7 +181,7 @@
             NSMutableDictionary* dict = [NSMutableDictionary new];
             [dict setObject:[self jsCallbackNameForSelector :_cmd] forKey:@"eventType"];
             [dict setObject:[self mapOfRegion:region] forKey:@"region"];
-            [dict setObject:@"error" forKey:error.description];
+            [dict setObject:error.description forKey:@"error"];
             
             CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:dict];
             [pluginResult setKeepCallbackAsBool:YES];

--- a/www/Delegate.js
+++ b/www/Delegate.js
@@ -48,6 +48,10 @@ Delegate.didDetermineStateForRegion = function(pluginResult) {
 	pluginResult.region = Regions.fromJson(pluginResult.region);
 };
 
+Delegate.monitoringDidFailForRegionWithError = function (pluginResult) {
+	pluginResult.region = Regions.fromJson(pluginResult.region);
+};
+
 Delegate.didStartMonitoringForRegion = function(pluginResult) {
 	pluginResult.region = Regions.fromJson(pluginResult.region);
 };
@@ -94,6 +98,10 @@ Delegate.safeTraceLogging = function(message) {
 
 Delegate.prototype.didDetermineStateForRegion = function() {
 	Delegate.safeTraceLogging('DEFAULT didDetermineStateForRegion()');
+};
+
+Delegate.prototype.monitoringDidFailForRegionWithError = function () {
+	Delegate.safeTraceLogging('DEFAULT monitoringDidFailForRegionWithError()');
 };
 
 Delegate.prototype.didStartMonitoringForRegion = function() {

--- a/www/LocationManager.js
+++ b/www/LocationManager.js
@@ -84,13 +84,16 @@ LocationManager.prototype.setDelegate = function(newDelegate) {
  * the DOM asynchronously about an event of it's own, for example entering 
  * into a region.
  * 
+ * The same callback will be used for success and fail handling since the
+ * handling is the same. 
+ *
  * @returns {Q.Promise}
  */
 LocationManager.prototype._registerDelegateCallbackId = function () {
 	this.appendToDeviceLog('registerDelegateCallbackId()');
 	var d = Q.defer();
 
-	exec(_.bind(this._onDelegateCallback, this, d), d.reject, "LocationManager",
+	exec(_.bind(this._onDelegateCallback, this, d), _.bind(this._onDelegateCallback, this, d), "LocationManager",
 		"registerDelegateCallbackId", []);
 
 	return d.promise;


### PR DESCRIPTION
In the iOS implementation, the callback monitoringDidFailForRegionWithError was already triggered. However, since it uses the status CDVCommandStatus_ERROR, the _onDelegateCallback in JavaScript never was called.

Therefore I changed _registerDelegateCallbackId to register _onDelegateCallback not only in the success case but also in the error case. So I get the monitoringDidFailForRegionWithError also in my Cordova application.