### PR TITLE
Remove empty space

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,8 +183,6 @@ delegate.didRangeBeaconsInRegion = function (pluginResult) {
     logToDom('[DOM] didRangeBeaconsInRegion: ' + JSON.stringify(pluginResult));
 };
 
-
-
 var uuid = '00000000-0000-0000-0000-000000000000';
 var identifier = 'beaconOnTheMacBooksShelf';
 var minor = 1000;


### PR DESCRIPTION
There's two examples:
"Start monitoring a single iBeacon" and "Start ranging a single iBeacon"
They are pretty much the same thing except two diferences, one has "startMonitoringForRegion" and the other "startRangingBeaconsInRegion", and one had two more line breaks, this PR fixes that...
