### PR TITLE
added NSBluetoothPeripheralUsageDescription to plist file

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -59,7 +59,9 @@
         <config-file target="*-Info.plist" parent="NSLocationWhenInUseUsageDescription">
             <string>This app would like to scan for iBeacons while it is in use.</string>
         </config-file>
-         
+        <config-file target="*-Info.plist" parent="NSBluetoothPeripheralUsageDescription">
+            <string>This app would like to scan for iBeacons.</string>
+        </config-file>
 
         <header-file src="src/ios/CDVLocationManager.h"/>
         <source-file src="src/ios/CDVLocationManager.m"/>


### PR DESCRIPTION
Fix for #271 issue:

```
Dear developer,

We have discovered one or more issues with your recent delivery for "[APP_NAME]". To process your delivery, the following issues must be corrected:

Missing Info.plist key - This app attempts to access privacy-sensitive data without a usage description. The app's Info.plist must contain an NSBluetoothPeripheralUsageDescription key with a string value explaining to the user how the app uses this data.

Once these issues have been corrected, you can then redeliver the corrected binary.

Regards,

The App Store team
```