### PR TITLE
Remove allowsBackgroundLocationUpdates from iOS LocationManager

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -13,9 +13,3 @@ Introduce an Android specific preference in your config.xml, something like this
     
 This will ensure that the AltBeacon library will wait five seconds in-between foreground scans.
 The default is 0 for the mentioned configuration value.
-
-### 'NSInternalInconsistencyException' Exception at Application Startup: ```Assertion failure in -[CLLocationManager setAllowsBackgroundLocationUpdates:]```
-
-This most likely happens because you forgot to enable the ```Background Modes``` capability by switching
-it to ```ON``` and then ticking ```Location updates``` as well. The messages and the stack trace may lead
-you to think that this is something to do with the UIWebView/WKWebView that you are using, but it is not.

--- a/src/ios/CDVLocationManager.m
+++ b/src/ios/CDVLocationManager.m
@@ -43,11 +43,6 @@
 - (void) initLocationManager {
     self.locationManager = [[CLLocationManager alloc] init];
     self.locationManager.delegate = self;
-    
-    
-    if (IsAtLeastiOSVersion(@"9.0")) {
-        self.locationManager.allowsBackgroundLocationUpdates = YES;
-    }
 }
 
 - (void) initPeripheralManager {


### PR DESCRIPTION
This PR removes the `LocationManager.allowsBackgroundLocationUpdates` for the iOS plugin code.

The code was causing issues (#212, #233) when being used with WKWebView (not sure why). The suggested fix, enabling background location updates capability, fixed the runtime error but would result in Apple rejecting the app. According to Apple the background location updates capability is not required for background beacon monitoring.

Background monitoring still works as long as the Location Always permission is granted. I tested this on iOS 11.0.3. The app was in a killed state (swiped from the recent apps, XCode confirmed app was not running) when testing.

The PR also updates the FAQ to remove the old suggested fix.