### PR TITLE
Fix cordova build error on cordova-android@7.0.0

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -121,7 +121,7 @@
         <source-file src="src/android/ILocationManagerCommand.java" target-dir="src/com/unarin/cordova/beacon" />
         <source-file src="src/android/PausableThreadPoolExecutor.java" target-dir="src/com/unarin/cordova/beacon" />
 
-		<source-file src="libs/android/altbeacon.jar" target-dir="libs" framework="true" />
+        <lib-file src="libs/android/altbeacon.jar" />
     </platform>
 
 </plugin>


### PR DESCRIPTION
This pull request fixes cordova build error on cordova-android@7.0.0.

Because the project directory structure has been changed by [cordova-android 7.0.0](https://cordova.apache.org/announcements/2017/12/04/cordova-android-7.0.0.html),
if `platforms/android/libs/` exists,
the directory structure is not recognized as new style(*1) and an error occurs.

`altbeacon.jar` should be copied to `platforms/android/app/libs/`
instead of `platforms/android/libs/`.

By using `<lib-file>` in plugin.xml, `altbeacon.jar` is copied to the appropriate directory.
(on cordova-android 7.0.0 and <=6.x)

(*1)
https://github.com/apache/cordova-android/blob/a7304b9a19a7b7f760d1bba240648a35130b295a/bin/templates/cordova/lib/AndroidStudio.js

##### Other approach

get altbeacon library from maven repository
https://github.com/deton/cordova-plugin-ibeacon/commit/d3488b6be04b3c8dc70c0ef56d9f9dab666d6ab1

##### Steps to reproduce the error

```
>cordova create foo com.example.foo foo
>cd foo
>cordova platform add android@7.0.0
>cordova plugin add cordova-plugin-ibeacon
>cordova build
cp: copyFileSync: could not write to dest file (code=ENOENT):C:\tmp\foo\platforms\android\res\xml\config.xml

Parsing C:\tmp\foo\platforms\android\res\xml\config.xml failed
(node:10160) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): Error: ENOENT: no such file or directory, open 'C:\tmp\foo\platforms\android\res\xml\config.xml'
(node:10160) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

Or add other plugin after `cordova plugin add cordova-plugin-ibeacon`.

```
>cordova create foo com.example.foo foo
>cd foo
>cordova platform add android@7.0.0
>cordova plugin add cordova-plugin-ibeacon
>cordova plugin add cordova-plugin-device
...
Installing "cordova-plugin-device" for android
Failed to install 'cordova-plugin-device': Error: ENOENT: no such file or directory, open 'C:\tmp\foo\platforms\android\AndroidManifest.xml'
    at Object.fs.openSync (fs.js:646:18)
    at Object.fs.readFileSync (fs.js:551:33)
    at Object.parseElementtreeSync (C:\tmp\foo\platforms\android\cordova\node_modules\cordova-common\src\util\xml-helpers.js:180:27)
    at new AndroidManifest (C:\tmp\foo\platforms\android\cordova\lib\AndroidManifest.js:29:20)
    at AndroidProject.getPackageName (C:\tmp\foo\platforms\android\cordova\lib\AndroidProject.js:99:12)
    at Api.addPlugin (C:\tmp\foo\platforms\android\cordova\Api.js:223:57)
    at handleInstall (C:\Users\deton\AppData\Roaming\npm\node_modules\cordova\node_modules\cordova-lib\src\plugman\install.js:594:10)
    at C:\Users\deton\AppData\Roaming\npm\node_modules\cordova\node_modules\cordova-lib\src\plugman\install.js:357:28
    at _fulfilled (C:\Users\deton\AppData\Roaming\npm\node_modules\cordova\node_modules\cordova-lib\node_modules\q\q.js:787:54)
    at self.promiseDispatch.done (C:\Users\deton\AppData\Roaming\npm\node_modules\cordova\node_modules\cordova-lib\node_modules\q\q.js:816:30)
(node:8416) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): Error: ENOENT: no such file or directory, open 'C:\tmp\foo\platforms\android\AndroidManifest.xml'
(node:8416) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

(no problem on cordova-android@6.4.0)

##### System info

* cordova-android 7.0.0
* cordova 8.0.0
* node.js v8.9.3
* Windows 10
