### PR TITLE
Removed eager queue resume

### DIFF
--- a/src/ios/CDVLocationManager.m
+++ b/src/ios/CDVLocationManager.m
@@ -37,7 +37,6 @@
     self.debugLogEnabled = true;
     self.debugNotificationsEnabled = false;
     
-    [self resumeEventPropagationToDom]; // DOM propagation when Location Manager, PeripheralManager initiated
 }
 
 - (void) initLocationManager {


### PR DESCRIPTION
# Description

When the application is executed, `LocationManager.onDomDelegateReady()` is supposed to be executed asap to inform the native layer that the javascript layer is ready to receive the plugin data (such as didEnterRegion events).

On the native layer, however, on `pluginInitialize`, the event queue is being resumed even before the javascript layer informs the native layer. 
This causes some events to be dropped if, for example, a didEnterRegion event happens before `LocationManager.onDomDelegateReady()` is executed.

Once `LocationManager.onDomDelegateReady()` is executed, the event queue is resumed once again.

# Fixes

Drop of events that happened immediately after app launch or events that caused the application to be executed while killed (swiped away).

Related to #259 .

# Reproduce

The easiest way I've found to reproduce this bug is:
- A simple cordova app with a setTimeout being triggered after deviceReady event that in turn set's the plugin's delegate.
- A Region registered for monitorization
- Kill the application (swipe the app away) and make the beacon to trigger an enter or exit event. This will launch the application in background mode and, using OSX Console app to watch logs.