### PR TITLE
fix: ibeacon crashing on android 8.x

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -130,6 +130,7 @@
         <source-file src="src/android/PausableThreadPoolExecutor.java" target-dir="src/com/unarin/cordova/beacon" />
 
         <lib-file src="libs/android/altbeacon.jar" />
+        <framework src="com.android.support:support-core-utils:26+" />
     </platform>
 
 </plugin>

--- a/plugin.xml
+++ b/plugin.xml
@@ -97,6 +97,7 @@
             <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
 			<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
             <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+            <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
         </config-file>
 
         <config-file target="AndroidManifest.xml" parent="/manifest/application">
@@ -122,6 +123,8 @@
                     <action android:name="com.unarin.cordova.beacon.IBeaconPlugin.DID_MONITORING" />
                 </intent-filter>
             </service>
+            <service android:name="org.altbeacon.beacon.service.ScanJob" 
+                     android:permission="android.permission.BIND_JOB_SERVICE" />
         </config-file>
 
         <source-file src="src/android/LocationManager.java" target-dir="src/com/unarin/cordova/beacon" />


### PR DESCRIPTION
I updated my Nexus 6P to android 8.x, An Ionic 4 app I'm developing started crashing every time I tried to use ibeacon.  Using ADB Logcat I noticed the error...

```
FATAL EXCEPTION: AsyncTask #4
Process: com.sprygroup.automata, PID: 27596
java.lang.RuntimeException: An error occurred while executing doInBackground()
       at android.os.AsyncTask$3.done(AsyncTask.java:353)
       at java.util.concurrent.FutureTask.finishCompletion(FutureTask.java:383)
       at java.util.concurrent.FutureTask.setException(FutureTask.java:252)
       at java.util.concurrent.FutureTask.run(FutureTask.java:271)
       at android.os.AsyncTask$SerialExecutor$1.run(AsyncTask.java:245)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1162)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:636)
       at java.lang.Thread.run(Thread.java:764)
Caused by: java.lang.NoClassDefFoundError: Failed resolution of: Landroid/support/v4/content/LocalBroadcastManager;
       at org.altbeacon.beacon.BeaconLocalBroadcastProcessor.unregister(BeaconLocalBroadcastProcessor.java:82)
       at org.altbeacon.beacon.BeaconLocalBroadcastProcessor.register(BeaconLocalBroadcastProcessor.java:74)
       at org.altbeacon.beacon.service.ScanJobScheduler.ensureNotificationProcessorSetup(ScanJobScheduler.java:69)
       at org.altbeacon.beacon.service.ScanJobScheduler.schedule(ScanJobScheduler.java:122)
       at org.altbeacon.beacon.service.ScanJobScheduler.applySettingsToScheduledJob(ScanJobScheduler.java:85)
       at org.altbeacon.beacon.service.ScanJobScheduler.applySettingsToScheduledJob(ScanJobScheduler.java:92)
       at org.altbeacon.beacon.BeaconManager.applyChangesToServices(BeaconManager.java:962)
       at org.altbeacon.beacon.BeaconManager.startMonitoringBeaconsInRegion(BeaconManager.java:902)
       at com.unarin.cordova.beacon.LocationManager$16.run(LocationManager.java:832)
       at com.unarin.cordova.beacon.LocationManager$33.doInBackground(LocationManager.java:1433)
       at com.unarin.cordova.beacon.LocationManager$33.doInBackground(LocationManager.java:1427)
       at android.os.AsyncTask$2.call(AsyncTask.java:333)
       at java.util.concurrent.FutureTask.run(FutureTask.java:266)
       ... 4 more
Caused by: java.lang.ClassNotFoundException: Didn't find class "android.support.v4.content.LocalBroadcastManager" on path: DexPathList[[zip file "/data/app/com.sprygroup.automata-wSTYa-9sJHZxG2fs4myqrA==/base.apk"],nativeLibraryDirectories=[/data/app/com.sprygroup.automata-wSTYa-9sJHZxG2fs4myqrA==/lib/arm64, /system/lib64, /vendor/lib64]]
       at dalvik.system.BaseDexClassLoader.findClass(BaseDexClassLoader.java:125)
       at java.lang.ClassLoader.loadClass(ClassLoader.java:379)
```

I added an explicit reference to the library in the plugin.xml and it seems to have resolved the crashing issue. 

possilbly applies to: 
* https://github.com/petermetz/cordova-plugin-ibeacon/issues/335
* https://github.com/petermetz/cordova-plugin-ibeacon/issues/340
* https://github.com/petermetz/cordova-plugin-ibeacon/issues/346
