### PR TITLE
Android 8 and fix problems with other CLLocationManagers from other plugins

### DIFF
--- a/src/ios/CDVLocationManager.m
+++ b/src/ios/CDVLocationManager.m
@@ -89,6 +89,7 @@
 
 - (void)locationManager:(CLLocationManager *)manager didDetermineState:(CLRegionState)state forRegion:(CLRegion *)region {
     
+    if (manager == self.locationManager) return;
     [self.commandDelegate runInBackground:^{
         
         [[self getLogger] debugLog:@"didDetermineState: %@ for region: %@", [self regionStateAsString:state], region];
@@ -107,6 +108,7 @@
 
 -(void)locationManager:(CLLocationManager *)manager didEnterRegion:(CLRegion *)region {
     
+    if (manager == self.locationManager) return;
     [self.queue addOperationWithBlock:^{
         
         [self _handleCallSafely:^CDVPluginResult *(CDVInvokedUrlCommand *command) {
@@ -128,6 +130,7 @@
 
 -(void)locationManager:(CLLocationManager *)manager didExitRegion:(CLRegion *)region {
 
+    if (manager == self.locationManager) return;
     [self.queue addOperationWithBlock:^{
         
         [self _handleCallSafely:^CDVPluginResult *(CDVInvokedUrlCommand *command) {
@@ -149,6 +152,7 @@
 
 - (void)locationManager:(CLLocationManager *)manager didStartMonitoringForRegion:(CLRegion *)region {
 
+    if (manager == self.locationManager) return;
     [self.queue addOperationWithBlock:^{
         
         [self _handleCallSafely:^CDVPluginResult *(CDVInvokedUrlCommand *command) {
@@ -169,6 +173,7 @@
 
 - (void)locationManager:(CLLocationManager *)manager monitoringDidFailForRegion:(CLRegion *)region withError:(NSError *)error {
     
+    if (manager == self.locationManager) return;
     [self.queue addOperationWithBlock:^{
         
         [self _handleCallSafely:^CDVPluginResult *(CDVInvokedUrlCommand *command) {
@@ -190,6 +195,7 @@
 
 - (void)locationManager:(CLLocationManager *)manager didRangeBeacons:(NSArray *)beacons inRegion:(CLBeaconRegion *)region {
     
+    if (manager == self.locationManager) return;
     NSMutableArray* beaconsMapsArray = [NSMutableArray new];
     for (CLBeacon* beacon in beacons) {
         NSDictionary* dictOfBeacon = [self mapOfBeacon:beacon];


### PR DESCRIPTION
Updated config.xml so it can work on Android 8 (Or at least Galaxy S9). And also when there are more than one CLLocationManager used by different plugins, only handles events coming in from our own.