### PR TITLE
fix path for beacon-library

### DIFF
--- a/src/android/cordova-plugin-ibeacon.gradle
+++ b/src/android/cordova-plugin-ibeacon.gradle
@@ -1,7 +1,7 @@
 repositories{
     jcenter()
     flatDir{
-        dirs 'libs'
+        dirs 'src/main/libs'
     }
 }
 


### PR DESCRIPTION
path is wrong for android 7.1.0, should be 
```
dirs: 'src/main/libs'
```

Error
> Could not find :android-beacon-library-2.13.1:.
> Searched in the following locations:
> ....
> ~~/platforms/android/app/libs/android-beacon-library-2.13.1.aar

Actual path is 
> ~~/platforms/android/app/src/main/libs/android-beacon-library-2.13.1.aar