### PR TITLE
Updated altBeacon library to 2.15.2

### DIFF
--- a/src/android/cordova-plugin-ibeacon.gradle
+++ b/src/android/cordova-plugin-ibeacon.gradle
@@ -3,7 +3,7 @@ repositories{
 }
 
 dependencies {
-    compile 'org.altbeacon:android-beacon-library:2.14'
+    compile 'org.altbeacon:android-beacon-library:2.15.2'
 }
 
 android {


### PR DESCRIPTION
This PR only increments the altbeacon library version.