### PR TITLE
Remove git+ from repo url

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/petermetz/cordova-plugin-ibeacon.git"
+    "url": "https://github.com/petermetz/cordova-plugin-ibeacon.git"
   },
   "keywords": [
     "cordova",


### PR DESCRIPTION
If the git+ is present, when removing and then adding platforms, cordova cannot find the plugin because the repository gives an error. Removing git+ from line 14 fixes the issue.