### PR TITLE
add ARMA filter support for distance calculations on Android

### DIFF
--- a/src/android/LocationManager.java
+++ b/src/android/LocationManager.java
@@ -53,6 +53,7 @@ import org.altbeacon.beacon.MonitorNotifier;
 import org.altbeacon.beacon.RangeNotifier;
 import org.altbeacon.beacon.Region;
 import org.altbeacon.beacon.service.RunningAverageRssiFilter;
+import org.altbeacon.beacon.service.ArmaRssiFilter;
 import org.altbeacon.beacon.service.RangedBeacon;
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaInterface;
@@ -81,6 +82,8 @@ public class LocationManager extends CordovaPlugin implements BeaconConsumer {
     private static final int DEFAULT_FOREGROUND_BETWEEN_SCAN_PERIOD = 0;
     private static final String SAMPLE_EXPIRATION_MILLISECOND = "com.unarin.cordova.beacon.android.altbeacon.SampleExpirationMilliseconds";
     private static final int DEFAULT_SAMPLE_EXPIRATION_MILLISECOND = 20000;
+    private static final String ENABLE_ARMA_FILTER_NAME = "com.unarin.cordova.beacon.android.altbeacon.EnableArmaFilter";
+    private static final boolean DEFAULT_ENABLE_ARMA_FILTER = false;
     private static final int DEFAULT_FOREGROUND_SCAN_PERIOD = 1100;
     private static int CDV_LOCATION_MANAGER_DOM_DELEGATE_TIMEOUT = 30;
     private static final int BUILD_VERSION_CODES_M = 23;
@@ -135,8 +138,16 @@ public class LocationManager extends CordovaPlugin implements BeaconConsumer {
         Log.i(TAG, "Determined config value SAMPLE_EXPIRATION_MILLISECOND: " +
                 String.valueOf(sampleExpirationMilliseconds));
 
-        iBeaconManager.setRssiFilterImplClass(RunningAverageRssiFilter.class);
-        RunningAverageRssiFilter.setSampleExpirationMilliseconds(sampleExpirationMilliseconds);
+        final boolean enableArmaFilter = this.preferences.getBoolean(
+                ENABLE_ARMA_FILTER_NAME, DEFAULT_ENABLE_ARMA_FILTER);
+
+        if(enableArmaFilter){
+               iBeaconManager.setRssiFilterImplClass(ArmaRssiFilter.class);
+        }
+        else{
+               iBeaconManager.setRssiFilterImplClass(RunningAverageRssiFilter.class);
+               RunningAverageRssiFilter.setSampleExpirationMilliseconds(sampleExpirationMilliseconds);
+        }
         RangedBeacon.setSampleExpirationMilliseconds(sampleExpirationMilliseconds);
 
         initBluetoothListener();


### PR DESCRIPTION
For some applications, the ARMA filter works better than the default rolling average. This commit adds support for the ARMA filter, which is enabled by setting the `com.unarin.cordova.beacon.android.altbeacon.EnableArmaFilter` preference to `true` in `config.xml`. The default behavior is not changed.