### PR TITLE
feat: add config option to request BT permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 
 #### Features exclusive to Android
  * ARMA filter for distance calculations
+ * Disable request for bluetooth permissions
 
 ### Installation
 
@@ -356,6 +357,12 @@ cordova.plugins.locationManager.startMonitoringForRegion(beaconRegion)
 The underlying library uses the moving average to calculate distance by default, but an ARMA filter can be enabled which will weigh more recent measurements higher than older measurements. It can be enabled by adding the following preference to your `config.xml` file:
 
 ```<preference name="com.unarin.cordova.beacon.android.altbeacon.EnableArmaFilter" value="true" />```
+
+#### Disable request for bluetooth permission
+By default, this library requests the user for bluetooth permissions when the app starts. If you would like to request permission in a different way or at a different time, set the following preference in your `config.xml` file.
+
+```<preference name="com.unarin.cordova.beacon.android.altbeacon.RequestBtPermission" value="false" />```
+
 
 ## Contributions
 

--- a/src/android/LocationManager.java
+++ b/src/android/LocationManager.java
@@ -84,6 +84,8 @@ public class LocationManager extends CordovaPlugin implements BeaconConsumer {
     private static final int DEFAULT_SAMPLE_EXPIRATION_MILLISECOND = 20000;
     private static final String ENABLE_ARMA_FILTER_NAME = "com.unarin.cordova.beacon.android.altbeacon.EnableArmaFilter";
     private static final boolean DEFAULT_ENABLE_ARMA_FILTER = false;
+    private static final String REQUEST_BT_PERMISSION_NAME = "com.unarin.cordova.beacon.android.altbeacon.RequestBtPermission";
+    private static final boolean DEFAULT_REQUEST_BT_PERMISSION = true;
     private static final int DEFAULT_FOREGROUND_SCAN_PERIOD = 1100;
     private static int CDV_LOCATION_MANAGER_DOM_DELEGATE_TIMEOUT = 30;
     private static final int BUILD_VERSION_CODES_M = 23;
@@ -163,7 +165,11 @@ public class LocationManager extends CordovaPlugin implements BeaconConsumer {
         }
         //TODO AddObserver when page loaded
 
-        tryToRequestMarshmallowLocationPermission();
+        final boolean requestPermission = this.preferences.getBoolean(
+                REQUEST_BT_PERMISSION_NAME, DEFAULT_REQUEST_BT_PERMISSION);
+           
+        if(requestPermission)
+              tryToRequestMarshmallowLocationPermission();
     }
 
     /**


### PR DESCRIPTION
This adds the option to disable the automatic BT permissions request when the app is started, giving more flexibility in how the app requests permission.