### PR TITLE
Added params on plugin install

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -84,8 +84,11 @@
         <framework src="CoreLocation.framework" />
 
     </platform>
-
     <platform name="android">
+	
+	<preference name="LOCATION_ACCESS_TITLE" value="This app needs location access" />
+	<preference name="LOCATION_ACCESS_DESCRIPTION" value="Please grant location access so this app can detect beacons." />	
+	
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="LocationManager" >
                 <param name="android-package" value="com.unarin.cordova.beacon.LocationManager"/>
@@ -103,6 +106,19 @@
 
         <framework src="src/android/cordova-plugin-ibeacon.gradle" custom="true" type="gradleReference" />
         <framework src="com.android.support:support-core-utils:26+" />
+		
+        <source-file src="src/android/location_access_string.xml" target-dir="res/values" />
+        <!-- Used for cordova-android 6 -->
+		 <config-file target="res/values/location_access_string.xml" parent="/*">
+            <string name="location_access_title">$LOCATION_ACCESS_TITLE</string>
+			<string name="location_access_description">$LOCATION_ACCESS_DESCRIPTION</string>
+        </config-file>
+        <!-- Used for cordova-android 7 -->
+		<config-file target="app/src/main/res/values/location_access_string.xml" parent="/*">
+            <string name="location_access_title">$LOCATION_ACCESS_TITLE</string>
+			<string name="location_access_description">$LOCATION_ACCESS_DESCRIPTION</string>
+        </config-file>
+		
     </platform>
 
 </plugin>

--- a/src/android/LocationManager.java
+++ b/src/android/LocationManager.java
@@ -317,8 +317,19 @@ public class LocationManager extends CordovaPlugin implements BeaconConsumer {
             }
 
             final AlertDialog.Builder builder = new AlertDialog.Builder(activity);
-            builder.setTitle("This app needs location access");
-            builder.setMessage("Please grant location access so this app can detect beacons.");
+			String title = cordova.getActivity().getString(cordova.getActivity().getResources().getIdentifier( "location_access_title", "string", cordova.getActivity().getPackageName()));			
+			String message = cordova.getActivity().getString(cordova.getActivity().getResources().getIdentifier( "location_access_description", "string", cordova.getActivity().getPackageName()));
+			
+			if (title == null || title.isEmpty()) {
+				title = "This app needs location access"; //default string for title
+			}
+			
+			if (message == null || message.isEmpty()) {
+				message = "Please grant location access so this app can detect beacons."; //default string for message
+			}
+			
+            builder.setTitle(title);
+            builder.setMessage(message);
             builder.setPositiveButton(android.R.string.ok, null);
             builder.setOnDismissListener(new DialogInterface.OnDismissListener() {
                 @SuppressLint("NewApi")

--- a/src/android/location_access_string.xml
+++ b/src/android/location_access_string.xml
@@ -1,0 +1,3 @@
+<?xml version='1.0' encoding='utf-8'?>
+<resources>
+</resources>


### PR DESCRIPTION
hi @petermetz 

I have created this pull request so that users can change the location access dialog box 's title and message by passing params during the installation of your plugin. I see many users wanted this change so I thought I could help with it. 

**Cordova Usage:**
`cordova plugin add https://github.com/petermetz/cordova-plugin-ibeacon.git --variable LOCATION_ACCESS_TITLE="This app needs location access" --variable LOCATION_ACCESS_DESCRIPTION="Please grant location access so this app can detect beacons."`

**Phonegap Usage:**
Add these lines to config.xml file of your project:
```
<plugin name="com.unarin.cordova.beacon" spec="3.8.1" />
        <variable name="LOCATION_ACCESS_TITLE" value="This app needs location access" />
        <variable name="LOCATION_ACCESS_DESCRIPTION" value="Please grant location access so this app can detect beacons." />
</plugin>
```

Specifying empty LOCATION_ACCESS_TITLE = "" or LOCATION_ACCESS_DESCRIPTION =""  string will use the default title and message.

Thank you