### PR TITLE
Update to altbeacon library 2.16.4

### DIFF
--- a/src/android/cordova-plugin-ibeacon.gradle
+++ b/src/android/cordova-plugin-ibeacon.gradle
@@ -3,7 +3,7 @@ repositories{
 }
 
 dependencies {
-    compile 'org.altbeacon:android-beacon-library:2.14'
+    compile 'org.altbeacon:android-beacon-library:2.15.2'
 }
 
 android {

--- a/src/android/cordova-plugin-ibeacon.gradle
+++ b/src/android/cordova-plugin-ibeacon.gradle
@@ -3,7 +3,7 @@ repositories{
 }
 
 dependencies {
-    compile 'org.altbeacon:android-beacon-library:2.16.4'
+    implementation 'org.altbeacon:android-beacon-library:2.19.3'
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
 }
 

--- a/src/android/cordova-plugin-ibeacon.gradle
+++ b/src/android/cordova-plugin-ibeacon.gradle
@@ -3,7 +3,7 @@ repositories{
 }
 
 dependencies {
-    implementation 'org.altbeacon:android-beacon-library:2.19.3'
+    implementation 'org.altbeacon:android-beacon-library:2.19.4'
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
 }
 

--- a/src/android/cordova-plugin-ibeacon.gradle
+++ b/src/android/cordova-plugin-ibeacon.gradle
@@ -4,6 +4,7 @@ repositories{
 
 dependencies {
     compile 'org.altbeacon:android-beacon-library:2.16.4'
+    implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
 }
 
 android {


### PR DESCRIPTION
chore: update altbeacon library

Simple update.  Also adds in the localbroadcastmanager dependency to ensure it builds cleanly.