### PR TITLE
add NSBluetoothAlwaysUsageDescription

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -64,6 +64,9 @@
         <config-file target="*-Info.plist" parent="NSLocationWhenInUseUsageDescription">
             <string>This app would like to scan for iBeacons while it is in use.</string>
         </config-file>
+        <config-file target="*-Info.plist" parent="NSBluetoothAlwaysUsageDescription">
+            <string>This app would like to scan for iBeacons.</string>
+        </config-file>
         <config-file target="*-Info.plist" parent="NSBluetoothPeripheralUsageDescription">
             <string>This app would like to scan for iBeacons.</string>
         </config-file>


### PR DESCRIPTION
When NSBluetoothAlwaysUsageDescription is missing apps targeting iOS 13 will crash with the following error:

Termination Reason: TCC, This app has crashed because it attempted to access privacy-sensitive data without a usage description. The app's Info.plist must contain an NSBluetoothAlwaysUsageDescription key with a string value explaining to the user how the app uses this data. 

This commit just adds that missing key.