### PR TITLE
Enable disabling of running average RSSI filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,12 @@ The underlying library uses the moving average to calculate distance by default,
 
 ```<preference name="com.unarin.cordova.beacon.android.altbeacon.EnableArmaFilter" value="true" />```
 
+##### Disable moving average for distance calculations (Android only)
+
+The underlying library uses the moving average to calculate distance by default. It can be disabled by adding the following preference to your `config.xml` file:
+
+```<preference name="com.unarin.cordova.beacon.android.altbeacon.EnableRunningAverageFilter" value="false" />```
+
 #### Disable request for bluetooth permission
 By default, this library requests the user for bluetooth permissions when the app starts. If you would like to request permission in a different way or at a different time, set the following preference in your `config.xml` file.
 

--- a/src/android/LocationManager.java
+++ b/src/android/LocationManager.java
@@ -84,6 +84,8 @@ public class LocationManager extends CordovaPlugin implements BeaconConsumer {
     private static final int DEFAULT_SAMPLE_EXPIRATION_MILLISECOND = 20000;
     private static final String ENABLE_ARMA_FILTER_NAME = "com.unarin.cordova.beacon.android.altbeacon.EnableArmaFilter";
     private static final boolean DEFAULT_ENABLE_ARMA_FILTER = false;
+    private static final String ENABLE_RUNNING_AVERAGE_FILTER_NAME = "com.unarin.cordova.beacon.android.altbeacon.EnableRunningAverageFilter";
+    private static final boolean DEFAULT_ENABLE_RUNNING_AVERAGE_FILTER = true;
     private static final String REQUEST_BT_PERMISSION_NAME = "com.unarin.cordova.beacon.android.altbeacon.RequestBtPermission";
     private static final boolean DEFAULT_REQUEST_BT_PERMISSION = true;
     private static final int DEFAULT_FOREGROUND_SCAN_PERIOD = 1100;
@@ -143,10 +145,13 @@ public class LocationManager extends CordovaPlugin implements BeaconConsumer {
         final boolean enableArmaFilter = this.preferences.getBoolean(
                 ENABLE_ARMA_FILTER_NAME, DEFAULT_ENABLE_ARMA_FILTER);
 
+        final boolean enableRunningAverageFilter = this.preferences.getBoolean(
+                ENABLE_RUNNING_AVERAGE_FILTER_NAME, DEFAULT_ENABLE_RUNNING_AVERAGE_FILTER);
+
         if(enableArmaFilter){
                iBeaconManager.setRssiFilterImplClass(ArmaRssiFilter.class);
         }
-        else{
+        else if(enableRunningAverageFilter){
                iBeaconManager.setRssiFilterImplClass(RunningAverageRssiFilter.class);
                RunningAverageRssiFilter.setSampleExpirationMilliseconds(sampleExpirationMilliseconds);
         }


### PR DESCRIPTION
You could choose between ARMA and regular running average. Now you can choose to disable running average in case you want the raw RSSIs without lag by setting `com.unarin.cordova.beacon.android.altbeacon.EnableRunningAverageFilter` to `false`